### PR TITLE
Update pagespeed-release naming; install git

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -228,7 +228,7 @@ sudo apt-get update
 sudo apt-get -y upgrade
 
 # Dependencies etc
-sudo apt-get install -y build-essential python ufw dpkg-dev zlib1g-dev libpcre3 libpcre3-dev unzip software-properties-common
+sudo apt-get install -y git build-essential python ufw dpkg-dev zlib1g-dev libpcre3 libpcre3-dev unzip software-properties-common
 
 
 # Pagespeed download
@@ -236,7 +236,7 @@ cd
 NPS_VERSION=1.11.33.2
 wget https://github.com/pagespeed/ngx_pagespeed/archive/release-${NPS_VERSION}-beta.zip -O release-${NPS_VERSION}-beta.zip
 unzip release-${NPS_VERSION}-beta.zip
-cd ngx_pagespeed-release-${NPS_VERSION}-beta/
+cd incubator-pagespeed-ngx-release-${NPS_VERSION}-beta/
 wget https://dl.google.com/dl/page-speed/psol/${NPS_VERSION}.tar.gz
 tar -xzvf ${NPS_VERSION}.tar.gz  # extracts to psol/
 
@@ -249,7 +249,7 @@ wget http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz
 tar -xvzf nginx-${NGINX_VERSION}.tar.gz
 cd nginx-${NGINX_VERSION}/
 ./configure \
---add-module=$HOME/ngx_pagespeed-release-${NPS_VERSION}-beta ${PS_NGX_EXTRA_FLAGS} \
+--add-module=$HOME/incubator-pagespeed-ngx-release-${NPS_VERSION}-beta ${PS_NGX_EXTRA_FLAGS} \
 --prefix=/etc/nginx  \
 --sbin-path=/usr/sbin/nginx  \
 --conf-path=/etc/nginx/nginx.conf  \


### PR DESCRIPTION
- install git in case it does not exist on fresh image since the script relies on git
- update the name of the nginx pagespeed release to what is retrieved: `incubator-pagespeed-ngx-release-${NPS_VERSION}-beta/` is the updated name